### PR TITLE
update TestFindPubKey to perform key image exploit, add LGPL license to ring-go files

### DIFF
--- a/ring/signature.go
+++ b/ring/signature.go
@@ -1,3 +1,19 @@
+// Copyright 2020 noot (elizabeth@chainsafe.io)
+// This file is part of ring-go.
+//
+// The ring-go library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The ring-go library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the ring-go library. If not, see <http://www.gnu.org/licenses/>.
+
 package ring
 
 import (

--- a/ring/signature_test.go
+++ b/ring/signature_test.go
@@ -1,3 +1,19 @@
+// Copyright 2020 noot (elizabeth@chainsafe.io)
+// This file is part of ring-go.
+//
+// The ring-go library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The ring-go library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the ring-go library. If not, see <http://www.gnu.org/licenses/>.
+
 package ring
 
 import (


### PR DESCRIPTION
to test:
```
go test ./... -run TestFindPubKey
```

you should see that the public key that signed the ring was found.

I also updated the license for the 2 files that contain code from ring-go, since it's licensed under LGPL.